### PR TITLE
【1.3.0.1】 改进自动修复，干掉x64

### DIFF
--- a/Ra3.Diagnosis.sln
+++ b/Ra3.Diagnosis.sln
@@ -7,18 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ra3.Diagnosis", "Ra3.Diagno
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A1BEEBBF-93BC-4F23-8447-97E29A8B2C4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A1BEEBBF-93BC-4F23-8447-97E29A8B2C4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1BEEBBF-93BC-4F23-8447-97E29A8B2C4D}.Debug|x86.ActiveCfg = Debug|x86
 		{A1BEEBBF-93BC-4F23-8447-97E29A8B2C4D}.Debug|x86.Build.0 = Debug|x86
-		{A1BEEBBF-93BC-4F23-8447-97E29A8B2C4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A1BEEBBF-93BC-4F23-8447-97E29A8B2C4D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A1BEEBBF-93BC-4F23-8447-97E29A8B2C4D}.Release|x86.ActiveCfg = Release|x86
 		{A1BEEBBF-93BC-4F23-8447-97E29A8B2C4D}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/Ra3.Diagnosis/Ra3.Diagnosis.csproj
+++ b/Ra3.Diagnosis/Ra3.Diagnosis.csproj
@@ -9,8 +9,8 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>AnyCPU;x86</Platforms>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-	<AssemblyVersion>1.3.0.0</AssemblyVersion>
-	<FileVersion>1.3.0.0</FileVersion>
+	<AssemblyVersion>1.3.0.1</AssemblyVersion>
+	<FileVersion>1.3.0.1</FileVersion>
 	<!--<PublishTrimmed>true</PublishTrimmed>
 	<_SuppressWinFormsTrimError>true</_SuppressWinFormsTrimError>-->
   </PropertyGroup>

--- a/Ra3.Diagnosis/Registry.cs
+++ b/Ra3.Diagnosis/Registry.cs
@@ -6,6 +6,12 @@ namespace Ra3.Diagnosis
 {
     internal static class Registry
     {
+        public static Dictionary<string, string> languageMap = new() {
+            { "english", "English (US)" },
+            { "chinese_t", "Chinese (Traditional)" },
+            { "chinese_s", "Chinese (Simplified)" },
+        };
+
         public static string GetGamePath()
         {
             using var view32 = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, string.Empty);
@@ -126,7 +132,7 @@ namespace Ra3.Diagnosis
             {
                 return false;
             }
-            ra3.SetValue("language", language, RegistryValueKind.String);
+            ra3.SetValue("language", languageMap[language], RegistryValueKind.String);
             return true;
         }
     }

--- a/Ra3.Diagnosis/Registry.cs
+++ b/Ra3.Diagnosis/Registry.cs
@@ -132,8 +132,9 @@ namespace Ra3.Diagnosis
             {
                 return false;
             }
-            ra3.SetValue("language", languageMap[language], RegistryValueKind.String);
-            return true;
+            var languageToSet = languageMap.ContainsKey(language) ? languageMap[language] : language;
+            ra3.SetValue("language", languageToSet, RegistryValueKind.String);
+            return true;    
         }
     }
 }


### PR DESCRIPTION
1. 改进--fix= 和 --clear
2. 删掉x64配置，避免注册表修错地方（实际上应该是WOW3264Node）
3. 解决语言修复不起作用的问题。