### PR TITLE
【1302】解决修复语言不起效的问题

### DIFF
--- a/Ra3.Diagnosis/Ra3.Diagnosis.csproj
+++ b/Ra3.Diagnosis/Ra3.Diagnosis.csproj
@@ -9,8 +9,8 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>AnyCPU;x86</Platforms>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-	<AssemblyVersion>1.3.0.1</AssemblyVersion>
-	<FileVersion>1.3.0.1</FileVersion>
+	<AssemblyVersion>1.3.0.2</AssemblyVersion>
+	<FileVersion>1.3.0.2</FileVersion>
 	<!--<PublishTrimmed>true</PublishTrimmed>
 	<_SuppressWinFormsTrimError>true</_SuppressWinFormsTrimError>-->
   </PropertyGroup>

--- a/Ra3.Diagnosis/Registry.cs
+++ b/Ra3.Diagnosis/Registry.cs
@@ -66,6 +66,7 @@ namespace Ra3.Diagnosis
             }
             using var view32 = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, string.Empty);
             using var ra3 = view32.OpenSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3", true);
+            // Register RegistryHive.CurrentUser because some old tools incorrectly use it...
             using var viewCu = RegistryKey.OpenRemoteBaseKey(RegistryHive.CurrentUser, string.Empty);
             using var ra3Cu = viewCu.OpenSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3", true);
 
@@ -89,6 +90,7 @@ namespace Ra3.Diagnosis
                 using var view32 = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, string.Empty);
                 view32.DeleteSubKeyTree("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3");
 
+                // Register RegistryHive.CurrentUser because some old tools incorrectly use it...
                 using var viewCu = RegistryKey.OpenRemoteBaseKey(RegistryHive.CurrentUser, string.Empty);
                 viewCu.DeleteSubKeyTree("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3");
             }
@@ -130,6 +132,7 @@ namespace Ra3.Diagnosis
             }
 
             // 修复注册表 (HKCU)
+            // Register RegistryHive.CurrentUser because some old tools incorrectly use it...
             using var viewCu = RegistryKey.OpenRemoteBaseKey(RegistryHive.CurrentUser, string.Empty);
             using var ra3Cu = viewCu.OpenSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3", true);
             if (ra3Cu == null)

--- a/Ra3.Diagnosis/Registry.cs
+++ b/Ra3.Diagnosis/Registry.cs
@@ -66,7 +66,10 @@ namespace Ra3.Diagnosis
             }
             using var view32 = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, string.Empty);
             using var ra3 = view32.OpenSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3", true);
-            if (ra3 == null)
+            using var viewCu = RegistryKey.OpenRemoteBaseKey(RegistryHive.CurrentUser, string.Empty);
+            using var ra3Cu = viewCu.OpenSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3", true);
+
+            if (ra3 == null || ra3Cu == null)
             {
                 return false;
             }
@@ -85,6 +88,9 @@ namespace Ra3.Diagnosis
             {
                 using var view32 = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, string.Empty);
                 view32.DeleteSubKeyTree("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3");
+
+                using var viewCu = RegistryKey.OpenRemoteBaseKey(RegistryHive.CurrentUser, string.Empty);
+                viewCu.DeleteSubKeyTree("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3");
             }
             catch { }
         }
@@ -96,6 +102,7 @@ namespace Ra3.Diagnosis
             path = Path.GetFullPath(path);
             var readmePath = Path.GetFullPath(Path.Combine(Path.Combine(path, "Support"), "readme.txt"));
 
+            // 修复注册表 (HKLM)
             using var view32 = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, string.Empty);
             using var ra3 = view32.OpenSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3", true);
             if (ra3 == null)
@@ -120,7 +127,15 @@ namespace Ra3.Diagnosis
                 newra3.SetValue("UseLocalUserMaps", 0, RegistryValueKind.DWord);
                 newra3.SetValue("UserDataLeafName", "Red Alert 3", RegistryValueKind.String);
                 newra3.CreateSubKey("ergc").SetValue(null, key, RegistryValueKind.String);
-                return;
+            }
+
+            // 修复注册表 (HKCU)
+            using var viewCu = RegistryKey.OpenRemoteBaseKey(RegistryHive.CurrentUser, string.Empty);
+            using var ra3Cu = viewCu.OpenSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3", true);
+            if (ra3Cu == null)
+            {
+                var newRa3Cu = viewCu.CreateSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3");
+                newRa3Cu.SetValue("Language", "english", RegistryValueKind.String);
             }
         }
 
@@ -128,13 +143,23 @@ namespace Ra3.Diagnosis
         {
             using var view32 = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, string.Empty);
             using var ra3 = view32.OpenSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3", true);
+
+            using var viewCu = RegistryKey.OpenRemoteBaseKey(RegistryHive.CurrentUser, string.Empty);
+            using var ra3Cu = viewCu.OpenSubKey("Software\\Electronic Arts\\Electronic Arts\\Red Alert 3", true);
+
             if (ra3 == null)
             {
                 return false;
             }
+            if (ra3Cu == null)
+            {
+                return false;
+            }
+
             var languageToSet = languageMap.ContainsKey(language) ? languageMap[language] : language;
             ra3.SetValue("language", languageToSet, RegistryValueKind.String);
-            return true;    
+            ra3Cu.SetValue("Language", language, RegistryValueKind.String);
+            return true;
         }
     }
 }


### PR DESCRIPTION
具体而言，读取语言是在**HKCU/[RA3RegistryPath]/Language**

所以我修了下

[红色警戒3诊断工具 1302.zip](https://github.com/user-attachments/files/18514655/3.1302.zip)
